### PR TITLE
Proposed NS004 reorder and NSWG discussion updates

### DIFF
--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -528,4 +528,4 @@ The security analysis SHOULD take into account and address the following princip
 
 The CA MUST ensure vulnerabilities are reviewed, responded to, and remediated in accordance with their established timeframe(s).
 
-The CA MUST document in Section 6.7 of their Certificate Policy and/or Certification Practices Statement each timeframe established for responding to and remediating vulnerabilities.
+Effective April 22, 2025, the CA MUST document in Section 6.7 of their Certificate Policy and/or Certification Practices Statement each timeframe established for responding to and remediating vulnerabilities.

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -469,11 +469,47 @@ These policies and procedures SHOULD apply to Security Support Systems.
 
 The CA MUST define an inventory of Certificate Systems.
 
-#### 4.2 Vulnerability management timeframe
+#### 4.2 Intrusion Detection and Prevention
 
-The CA MUST establish a timeframe for responding to and remediating critical and non-critical vulnerabilities.
-This timeframe MUST be established based on a risk assessment performed by the CA.
+The CA MUST protect the inventory of Certificate Systems against common network and system threats using intrusion detection and prevention controls.
+
+Some common network and system threats include, but are not limited to:
+
+* malicious software;
+* phishing and social engineering;
+* denial of service;
+* unauthorized access; and
+* malicious data injection.
+
+#### 4.3 Vulnerability Correction Process
+
+The CA MUST document and follow a vulnerability correction process that includes:
+
+   1. identification;
+   1. review;
+   1. response; and
+   1. remediation.
+
+#### 4.4 Vulnerability Identification
+
+##### 4.4.1 Penetration Testing
+
+As part of the identification component of the CA's vulnerability correction process, the CA MUST define and follow a program for performing penetration tests that ensures:
+
+   1. penetration tests are performed:
+      * at least on an annual basis; and
+      * after infrastructure or application changes that are organizationally defined as significant; and
+   2. penetration tests are performed by a person or entity (or collective group thereof) with the requisite skills, tools, proficiency, code of ethics, and independence; and
+   3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in [Section 4.3](#43-vulnerability-correction-process).
+
+#### 4.5 Vulnerability Management Timeframe
+
+The CA MUST establish one or more timeframes for reviewing, responding to, and remediating all identified vulnerabilities.
+
+Each timeframe MUST be established based on a risk assessment performed by the CA.
+
 The risk assessment MUST be based on a documented security analysis.
+
 The security analysis SHOULD take into account and address the following principles:
 
 * criticality of assets;
@@ -486,40 +522,6 @@ The security analysis SHOULD take into account and address the following princip
 * historical data; and
 * present threat landscape.
 
-The CA MUST ensure critical and non-critical vulnerabilities are responded to and remediated in accordance with their established timeframe.
+The CA MUST ensure vulnerabilities are reviewed, responded to, and remediated in accordance with their established timeframe(s).
 
-The CA MUST document in their Certificate Policy and/or Certification Practices Statement the timeframe established for responding to and remediating critical and non-critical vulnerabilities.
-
-#### 4.3 Intrusion Detection and Prevention
-
-Intrusion detection and prevention controls MUST protect the inventory of Certificate Systems against common network and system threats.
-
-Some common network and system threats include, but are not limited to:
-
-* malicious software;
-* phishing and social engineering;
-* denial of service;
-* unauthorized access; and
-* malicious data injection.
-
-#### 4.4 Vulnerability Correction
-
-The CA MUST document and follow a vulnerability correction process that includes:
-
-   1. periodic vulnerability scanning;
-   2. identification;
-   3. review;
-   4. response; and
-   5. remediation  (i.e. vulnerabilities are tracked to ensure their remediation is completed within a defined timeframe).
-
-#### 4.5 Penetration Testing
-
-The CA MUST define and follow a program for performing penetration tests.
-
-A defined program for performing penetration tests MUST ensure that:
-
-   1. penetration tests are performed:
-      * at least on an annual basis; and
-      * after infrastructure or application changes that are organizationally defined as significant; and
-   2. penetration tests are performed by a person or entity (or collective group thereof) with the requisite skills, tools, proficiency, code of ethics, and independence; and
-   3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in [Section 4.4](#44-vulnerability-correction).
+The CA MUST document in Section 6.7 of their Certificate Policy and/or Certification Practices Statement each timeframe established for responding to and remediating vulnerabilities.

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -471,7 +471,7 @@ The CA MUST define an inventory of Certificate Systems.
 
 #### 4.2 Intrusion Detection and Prevention
 
-The CA MUST protect the inventory of Certificate Systems against common network and system threats using intrusion detection and prevention controls.
+The CA MUST protect the systems in the inventory of Certificate Systems against common network and system threats using intrusion detection and prevention controls.
 
 Some common network and system threats include, but are not limited to:
 
@@ -489,6 +489,11 @@ The CA MUST document and follow a vulnerability correction process that includes
    1. review;
    1. response; and
    1. remediation.
+
+A vulnerability is remediated when the CA has:
+
+* fixed the vulnerability such that the vulnerability is no longer present; or
+* confirmed the impact of the vulnerability and thoroughly documented why the vulnerability cannot be exploited.
 
 #### 4.4 Vulnerability Identification
 
@@ -514,7 +519,6 @@ The security analysis SHOULD take into account and address the following princip
 
 * criticality of assets;
 * maintaining confidentiality, integrity, and availability of assets;
-* risk tolerance;
 * regulatory requirements;
 * likelihood and impact of exploitation;
 * dependencies and interdependencies;


### PR DESCRIPTION
- Reordering the subsections in Section 4
- Removing "critical and non-critical" (all vulnerabilities need to be accounted for)
- Remove "periodic vulnerability scanning" (it's part of identification)
- Move clarification about what remediating a vulnerability entails to below the list in the Vulnerability Correction Process subsection
- Remove "risk tolerance" from security analysis principles (the analysis is in support of a risk assessment)
- Add effective date for disclosing remediation timeframes in CP/CPS
- Add Section 6.7 as required location in CP/CPS for disclosing remediation timeframe in CP/CPS
- Spacing and markdown fixes
- Account for multiple timeframes being established
- Clarify that the systems are what needs to be protected, not the inventory of systems
